### PR TITLE
removed redundant init

### DIFF
--- a/Classes/RLDPushPopNavigationCommand.swift
+++ b/Classes/RLDPushPopNavigationCommand.swift
@@ -1,12 +1,6 @@
 import UIKit
 
 class RLDPushPopNavigationCommand:RLDDirectNavigationCommand {
-    
-    // MARK:Initialisation
-    
-    override required init?(navigationSetup:RLDNavigationSetup) {
-        super.init(navigationSetup: navigationSetup)
-    }
 
     // MARK: Suitability checking
     


### PR DESCRIPTION
removed an init method that has the same signature of its parent and don’t do anything else than calling the parent init
